### PR TITLE
explicitly set the featureId and featureVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ repositories {
 	jcenter()
 }
 
+// project version is also platform feature version default,
+// here uses TestNG version as project version.
 version = '6.9.12'
 
 defaultTasks 'clean', 'updateSiteZip'

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,15 @@ version = '6.9.12'
 defaultTasks 'clean', 'updateSiteZip'
 
 platform {
-	bundle "org.testng:testng:${version}"
+	feature(id: 'org.testng.p2.feature', name: 'TestNG Feature') {
+		plugin "org.testng:testng:${version}", {
+			exclude module: 'ant'
+		}
+	}
+
 	featureId 'org.testng.p2.feature'
 	featureName 'TestNG Feature'
+
 	categoryName 'TestNG Libraries'
 	categoryId 'org.testng.p2.libraries'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,12 @@ repositories {
 	jcenter()
 }
 
+version = '6.9.12'
+
 defaultTasks 'clean', 'updateSiteZip'
 
 platform {
-	bundle 'org.testng:testng:6.9.12'
+	bundle "org.testng:testng:${version}"
 	featureId 'org.testng.p2.feature'
 	featureName 'TestNG Feature'
 	categoryName 'TestNG Libraries'

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ defaultTasks 'clean', 'updateSiteZip'
 
 platform {
 	bundle 'org.testng:testng:6.9.12'
+	featureId 'org.testng.p2.feature'
+	featureName 'TestNG Feature'
 	categoryName 'TestNG Libraries'
 	categoryId 'org.testng.p2.libraries'
 }


### PR DESCRIPTION
for #2 

now the output looks like below:

```
ll build/updatesite/*
-rw-r--r--  1 nick  staff   1.0K Oct  6 00:10 build/updatesite/artifacts.jar
-rw-r--r--  1 nick  staff   2.4K Oct  6 00:10 build/updatesite/content.jar

build/updatesite/features:
total 8
-rw-r--r--  1 nick  staff   437B Oct  6 00:10 org.testng.p2.feature_6.9.12.bnd-dZJevA.jar

build/updatesite/plugins:
total 9896
-rw-r--r--  1 nick  staff    54K Oct  6 00:10 com.beust.jcommander.source_1.48.0.jar
-rw-r--r--  1 nick  staff    62K Oct  6 00:10 com.beust.jcommander_1.48.0.jar
-rw-r--r--  1 nick  staff    12K Oct  6 00:10 org.apache.ant.launcher_1.7.0.bnd-vDsQ7g.jar
-rw-r--r--  1 nick  staff   1.9M Oct  6 00:10 org.apache.ant.source_1.7.0.bnd-vDsQ7g.jar
-rw-r--r--  1 nick  staff   1.2M Oct  6 00:10 org.apache.ant_1.7.0.bnd-vDsQ7g.jar
-rw-r--r--  1 nick  staff   279K Oct  6 00:10 org.beanshell.bsh_2.0.0.b4-bnd-u7kQ6A.jar
-rw-r--r--  1 nick  staff   473K Oct  6 00:10 org.testng.source_6.9.12.jar
-rw-r--r--  1 nick  staff   821K Oct  6 00:10 org.testng_6.9.12.jar
```

CC: @mschreiber