### PR TITLE
Forcing the com.google.common packages as optional imports, do not add a

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ defaultTasks 'clean', 'updateSiteZip'
 
 platform {
 	feature(id: 'org.testng.p2.feature', name: 'TestNG Feature') {
+	    bnd {
+            optionalImport 'com.google.common.*'
+        }
 		plugin "org.testng:testng:${version}", {
 			exclude module: 'ant'
 		}
@@ -35,6 +38,9 @@ platform {
 
 	categoryName 'TestNG Libraries'
 	categoryId 'org.testng.p2.libraries'
+	
+	useBndHashQualifiers false
+    defaultQualifier ''
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
generated qualifier

This forces/overrides the import of com.google.common to be optional and
fixes issue #6. bnd adds for changed bundles a hash as qualifier. With
useBndQualifiers false and an empty defaultQualifier, bnd does not
change the name of the generated jars, so they end up with the same name
as in the maven repo