### PR TITLE
add .travis.yml to trigger ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+language: java
+cache:
+  directories:
+  - $HOME/.gradle
+
+jdk:
+  - oraclejdk7
+
+script:
+  - ./gradlew


### PR DESCRIPTION
hi @mschreiber 
see if you can access this travis-ci job by login with your github account:
https://travis-ci.org/testng-team/testng-p2

to enable travis-ci build, we simply add the `.travis.yml` file under the project root.

for now, it's just call the gradle build with default tasks, in future, will add more step (or gradle task) to  publish the update-site to bintray, i'm still working on that, see more in #3 