### PR TITLE
#10: fix the feature version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ repositories {
 // here uses TestNG version as project version.
 version = '6.9.13-SNAPSHOT'
 
-def versionWithQualifier = version.replaceAll('SNAPSHOT', buildTime())
+def versionWithQualifier = version.replaceAll('-SNAPSHOT', "." + buildTime())
 
 defaultTasks 'clean', 'updateSiteZip'
 
@@ -43,6 +43,7 @@ platform {
 
 	featureId 'org.testng.p2.feature'
 	featureName 'TestNG Feature'
+	featureVersion versionWithQualifier
 
 	categoryName 'TestNG Libraries'
 	categoryId 'org.testng.p2.libraries'


### PR DESCRIPTION
hi @mschreiber 
for now, the feature version on the jar file was:
```
features:
total 16
-rw-r--r--  1 nick  staff   418B Oct 15 05:41 org.testng.p2.feature.source_6.9.13.SNAPSHOT-bnd-hApPw.jar
-rw-r--r--  1 nick  staff   451B Oct 15 05:41 org.testng.p2.feature_1.0.0.bnd-AnRzsQ.jar
```

so the PR is to fix the feature version to be consistent with the qualified Version:
```
features:
total 16
-rw-r--r--  1 nick  staff   420B Oct 15 05:44 org.testng.p2.feature.source_6.9.13.SNAPSHOT-bnd-nYpRQ.jar
-rw-r--r--  1 nick  staff   455B Oct 15 05:44 org.testng.p2.feature_6.9.13.20161015124418-bnd-CFpzsQ.jar
```
