### PR TITLE
fix the jcommander osgi header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,15 @@ platform {
         }
     }
 
+    bundle "com.beust:jcommander:1.72", {
+        bnd {
+            // override/set the symbolic name
+            symbolicName = 'com.beust.jcommander'
+            // override/set the bundle name
+            bundleName = 'jcommander'
+        }
+    }
+
     featureId 'org.testng.p2.feature'
     featureName 'TestNG P2 Feature'
     featureVersion versionWithQualifier


### PR DESCRIPTION
----
relate build failure:
[ERROR] Cannot resolve project dependencies:
[ERROR]   Software being installed: org.testng.eclipse 6.13.0.qualifier
[ERROR]   Missing requirement: org.testng 6.13.1.r201712040202 requires 'bundle com.beust.jcommander [1.7.0,2.0.0)' but it could not be found