### PR TITLE
feat: remove slf4j-api out of the p2 bundle to avoid the build failure in testng-eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,16 +81,10 @@ platform {
         exclude module: 'junit'
         exclude module: 'jsr305'
         exclude module: 'guice'
+        exclude module: 'slf4j-api'
     }
 
     bundle "org.yaml:snakeyaml:2.2"
-    bundle "org.slf4j:slf4j-api:2.0.16"
-
-    bundle "org.apache-extras.beanshell:bsh:2.0b6", {
-        bnd {
-            optionalImport 'org.apache.bsf.*'
-        }
-    }
 
     bundle "org.jcommander:jcommander:1.83", {
         bnd {


### PR DESCRIPTION
solve the build failure by exclude the slf4j-api out of the testng-p2 repo, as the slf4j-api osgi bundle is available in the eclipse installation package out of the box.
```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:4.0.12:validate-classpath (default-validate-classpath) on project org.testng.eclipse: Execution default-validate-classpath of goal org.eclipse.tycho:tycho-compiler-plugin:4.0.12:validate-classpath failed: org.osgi.framework.BundleException: Bundle org.testng.eclipse cannot be resolved:org.testng.eclipse [132]
[ERROR]   Unresolved requirement: Require-Bundle: org.testng; bundle-version="[6.9.12,8.0.0)"
[ERROR]     -> Bundle-SymbolicName: org.testng; bundle-version="7.11.0.r202502150124"
[ERROR]        org.testng [128]
[ERROR]          Unresolved requirement: Import-Package: org.slf4j
[ERROR]            -> Export-Package: org.slf4j; bundle-symbolic-name="slf4j.api"; bundle-version="2.0.16"; version="1.7.36"
[ERROR]               slf4j.api [3]
[ERROR]                 Unresolved requirement: Require-Capability: osgi.extender; filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))"
```